### PR TITLE
Fix bug while preparing file name when selecting from library with di…

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -714,7 +714,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
         // if the picture is not a jpeg or png, (a .heic for example) when processed to a bitmap
         // the file extension is changed to the output format, f.e. an input file my_photo.heic could become my_photo.jpg
-        return fileName.substring(fileName.lastIndexOf(".") + 1) + getExtensionForEncodingType();
+        return fileName.substring(0, fileName.lastIndexOf(".")) + getExtensionForEncodingType();
     }
 
     private String getExtensionForEncodingType() {


### PR DESCRIPTION


<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android
- iOS

### Motivation and Context
Previously, PNG images were being converted to JPG during processing. Additionally, image scaling logic did not handle cases where the uploaded image was smaller than the specified width and height, which could result in unnecessary or undesired upscaling.

### Description

- Fixed image processing to retain PNG format instead of converting it to JPG.
- Added check to skip scaling when the original image is smaller than the provided width and height.



### Testing

- Verified image format retention (PNG stays PNG) after processing on both platforms.
- Confirmed that scaling is skipped for smaller images.
- Tested various image types (PNG, JPG) across devices on both Android and iOS.
- Ensured no regressions in other image processing functionalities.



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
